### PR TITLE
Dispatch repository events to Integration Tests repository

### DIFF
--- a/.github/workflows/repository-dispatcher.yml
+++ b/.github/workflows/repository-dispatcher.yml
@@ -1,0 +1,29 @@
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at:
+#
+#     https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+name: Repository Dispatcher
+
+on: [push, pull_request]
+
+jobs:
+  dispatch-events:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch repository event
+        run: |
+          curl -X POST https://api.github.com/repos/jshiftio/jkube-integration-tests/dispatches \
+          -H 'Accept: application/vnd.github.everest-preview+json' \
+          -u ${{ secrets.dispatcher_username }}:${{ secrets.dispatcher_password }} \
+          --data '{"event_type": "jkube_webhook", "client_payload": { "repository": "'"$GITHUB_REPOSITORY"'", "revision": "'$(echo "$GITHUB_REF" | sed -E 's/refs\/(heads|tags)\///')'" }}'
+
+


### PR DESCRIPTION
A workflow that will trigger Integration tests in a remote repository (See: https://github.com/jshiftio/jkube-integration-tests/blob/master/.github/workflows/integration-tests.yml).

There is an **alternative** approach to perform the opposite of the current workflow so that integration tests run in this repository. This would imply creating a workflow in JKube that would clone the integration tests repository so that tests could be run in the workflow's context.
GitHub checks would also be enabled in this scenario.
**Please comment if you think this would be a better solution**

Relates to: https://github.com/jkubeio/jkube/issues/21